### PR TITLE
[codex] Add HEMS configurator API fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 - Client compatibility: when newer KiwOS Edge systems no longer expose `/rest/items` or `/rest/things`, fall back to `/rest/hems-configurator/energy-overview` for live power sensors and `/rest/hems-configurator/things` for diagnostics metadata.
+- Options UI: added an opt-in, read-only Modbus data setting for compatible vision/FoxESS-style systems. When enabled, the HEMS fallback also creates additional PV/grid/battery energy totals, BMS health/electrical sensors, inverter status/fault sensors, and battery policy/limit sensors where the registers validate.
 
 ## 2026.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+- Client compatibility: when newer KiwOS Edge systems no longer expose `/rest/items` or `/rest/things`, fall back to `/rest/hems-configurator/energy-overview` for live power sensors and `/rest/hems-configurator/things` for diagnostics metadata.
+
 ## 2026.5.0
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Note for users with **vision** components: If you need write/control functions s
 
 * Local polling of SOLARWATT Manager data
 * Compatibility with newer KiwOS Edge systems that expose live power data via the HEMS configurator API
+* Optional read-only Modbus polling for compatible vision/FoxESS-style systems, adding extra PV/grid/battery energy totals, BMS health/electrical sensors, inverter status/fault sensors, and battery policy/limit sensors
 * Energy Dashboard ready (correct `device_class` & `state_class`)
 * Automatic normalization of units and item names, including Wh → kWh conversion, removal of installation-specific IDs, collapsed duplicate fragments, and preserved abbreviations such as BMS/SoC/SoH
 * Device-based entity structure: entities are assigned to their SOLARWATT devices and `entity_id`s are built from the Home Assistant device name plus the normalized channel name
@@ -85,6 +86,7 @@ You can adjust these in the integration options:
 * **Energy delta (kWh)** – write energy updates only if the change is >= threshold; set to `0` to write every update
 * **Power unavailable threshold (polls)** – applies to power sensors only. If SOLARWATT briefly returns `unavailable`, the last valid power value is kept until the configured consecutive poll limit is reached. Example: `3` means the 1st and 2nd `unavailable` poll keep the previous value, and the sensor only switches to `unavailable` on the 3rd poll. Set to `0` to disable this debounce completely.
 * **Disable duplicate item entities** – disabled by default. When enabled and a thing channel exposes multiple linked items for the same value, the integration keeps the UID-based channel item (for example `keba_wallbox_12345678_channels_state`) active and creates the additional item entities as disabled-by-default entries. They remain visible in Home Assistant and can still be enabled manually.
+* **Read additional inverter and battery data via Modbus** – disabled by default. On compatible vision/FoxESS-style systems, this adds read-only Modbus-backed sensors for energy totals, battery/BMS health, battery electrical state, inverter status/faults, and battery limits. No write/control Modbus commands are used.
 * **Device selection** – choose which detected SOLARWATT devices should be created in Home Assistant
 * **Rebuild entity IDs when saving** – rebuild managed `entity_id`s using `device name + sensor name`
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Note for users with **vision** components: If you need write/control functions s
 ## ✨ Features
 
 * Local polling of SOLARWATT Manager data
+* Compatibility with newer KiwOS Edge systems that expose live power data via the HEMS configurator API
 * Energy Dashboard ready (correct `device_class` & `state_class`)
 * Automatic normalization of units and item names, including Wh → kWh conversion, removal of installation-specific IDs, collapsed duplicate fragments, and preserved abbreviations such as BMS/SoC/SoH
 * Device-based entity structure: entities are assigned to their SOLARWATT devices and `entity_id`s are built from the Home Assistant device name plus the normalized channel name

--- a/custom_components/solarwatt_manager/client.py
+++ b/custom_components/solarwatt_manager/client.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass
 import logging
 import struct
 import time
@@ -15,12 +17,315 @@ from .hems_api import (
     battery_soc_to_legacy_items,
     energy_overview_to_items,
     energy_overview_to_legacy_items,
+    extended_modbus_to_legacy_items,
     things_to_openhab_things,
 )
 
 _FOXESS_BATTERY_SOC_ADDRESSES = (37612, 31024, 31038, 38310)
 _MODBUS_READ_HOLDING_REGISTERS = 3
 _MODBUS_READ_INPUT_REGISTERS = 4
+
+
+@dataclass(frozen=True)
+class _ModbusCandidate:
+    addresses: tuple[int, ...]
+    scale: float = 1.0
+    signed: bool = False
+    min_value: float | None = None
+    max_value: float | None = None
+    transform: Callable[[int], int | float | str] | None = None
+
+
+@dataclass(frozen=True)
+class _ModbusSensorSpec:
+    key: str
+    candidates: tuple[_ModbusCandidate, ...]
+
+
+def _candidate(
+    *addresses: int,
+    scale: float = 1.0,
+    signed: bool = False,
+    min_value: float | None = None,
+    max_value: float | None = None,
+    transform: Callable[[int], int | float | str] | None = None,
+) -> _ModbusCandidate:
+    return _ModbusCandidate(
+        tuple(addresses),
+        scale=scale,
+        signed=signed,
+        min_value=min_value,
+        max_value=max_value,
+        transform=transform,
+    )
+
+
+def _cell_voltage(raw: int) -> float:
+    return raw / 1000 if raw >= 1000 else raw * 0.1
+
+
+def _normal_work_mode_name(code: int) -> str:
+    return {
+        0: "Self Use",
+        1: "Feed-in First",
+        2: "Back-up",
+        4: "Peak Shaving",
+    }.get(code, f"Unknown ({code})")
+
+
+def _h3_pro_work_mode_name(code: int) -> str:
+    return {
+        1: "Self Use",
+        2: "Feed-in First",
+        3: "Back-up",
+        4: "Peak Shaving",
+    }.get(code, f"Unknown ({code})")
+
+
+_EXTENDED_MODBUS_SPECS: tuple[_ModbusSensorSpec, ...] = (
+    _ModbusSensorSpec(
+        "solar_energy_total",
+        (
+            _candidate(39602, 39601, scale=0.01, min_value=0),
+            _candidate(32001, 32000, scale=0.1, min_value=0),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "solar_energy_today",
+        (
+            _candidate(39604, 39603, scale=0.01, min_value=0, max_value=1000),
+            _candidate(32002, scale=0.1, min_value=0, max_value=1000),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "battery_charge_total",
+        (
+            _candidate(39606, 39605, scale=0.01, min_value=0),
+            _candidate(32004, 32003, scale=0.1, min_value=0),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "battery_charge_today",
+        (
+            _candidate(39608, 39607, scale=0.01, min_value=0, max_value=1000),
+            _candidate(32005, scale=0.1, min_value=0, max_value=1000),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "battery_discharge_total",
+        (
+            _candidate(39610, 39609, scale=0.01, min_value=0),
+            _candidate(32007, 32006, scale=0.1, min_value=0),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "battery_discharge_today",
+        (
+            _candidate(39612, 39611, scale=0.01, min_value=0, max_value=1000),
+            _candidate(32008, scale=0.1, min_value=0, max_value=1000),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "feed_in_energy_total",
+        (
+            _candidate(39614, 39613, scale=0.01, min_value=0),
+            _candidate(32010, 32009, scale=0.1, min_value=0),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "feed_in_energy_today",
+        (
+            _candidate(39616, 39615, scale=0.01, min_value=0, max_value=1000),
+            _candidate(32011, scale=0.1, min_value=0, max_value=1000),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "grid_consumption_energy_total",
+        (
+            _candidate(39618, 39617, scale=0.01, min_value=0),
+            _candidate(32013, 32012, scale=0.1, min_value=0),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "grid_consumption_energy_today",
+        (
+            _candidate(39620, 39619, scale=0.01, min_value=0, max_value=1000),
+            _candidate(32014, scale=0.1, min_value=0, max_value=1000),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "total_yield_total",
+        (
+            _candidate(39622, 39621, scale=0.01, min_value=0),
+            _candidate(32016, 32015, scale=0.1, min_value=0),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "total_yield_today",
+        (
+            _candidate(39624, 39623, scale=0.01, min_value=-200, max_value=200),
+            _candidate(32017, scale=0.1, min_value=-200, max_value=200),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "input_energy_total",
+        (
+            _candidate(39626, 39625, scale=0.01, min_value=0),
+            _candidate(32019, 32018, scale=0.1, min_value=0),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "input_energy_today",
+        (
+            _candidate(39628, 39627, scale=0.01, min_value=-1000, max_value=1000),
+            _candidate(32020, scale=0.1, min_value=-1000, max_value=1000),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "battery_bms_1_voltage",
+        (
+            _candidate(37609, scale=0.1, min_value=100, max_value=600),
+            _candidate(31034, scale=0.1, min_value=100, max_value=600),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "battery_bms_1_current",
+        (
+            _candidate(37610, scale=0.1, signed=True, min_value=-100, max_value=100),
+            _candidate(31035, scale=0.1, signed=True, min_value=-100, max_value=100),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "battery_bms_1_temperature",
+        (
+            _candidate(37611, scale=0.1, signed=True, min_value=-50, max_value=100),
+            _candidate(31037, scale=0.1, signed=True, min_value=-50, max_value=100),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "battery_bms_1_soh",
+        (
+            _candidate(37624, min_value=0, max_value=100),
+            _candidate(31090, min_value=0, max_value=100),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "battery_bms_1_cell_temperature_high",
+        (_candidate(37617, scale=0.1, signed=True, min_value=-50, max_value=100),),
+    ),
+    _ModbusSensorSpec(
+        "battery_bms_1_cell_temperature_low",
+        (_candidate(37618, scale=0.1, signed=True, min_value=-50, max_value=100),),
+    ),
+    _ModbusSensorSpec(
+        "battery_bms_1_cell_voltage_high",
+        (_candidate(37619, min_value=0, max_value=5, transform=_cell_voltage),),
+    ),
+    _ModbusSensorSpec(
+        "battery_bms_1_cell_voltage_low",
+        (_candidate(37620, min_value=0, max_value=5, transform=_cell_voltage),),
+    ),
+    _ModbusSensorSpec(
+        "battery_bms_1_kwh_remaining",
+        (_candidate(37632, scale=0.01, min_value=0),),
+    ),
+    _ModbusSensorSpec(
+        "bms_1_connect_state",
+        (_candidate(37002, min_value=0, max_value=10),),
+    ),
+    _ModbusSensorSpec(
+        "inverter_temperature",
+        (
+            _candidate(39141, scale=0.1, signed=True, min_value=-50, max_value=100),
+            _candidate(31032, scale=0.1, signed=True, min_value=-50, max_value=100),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "inverter_state_code",
+        (
+            _candidate(39063, min_value=0),
+            _candidate(31041, min_value=0),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "inverter_fault_1_code",
+        (
+            _candidate(39067, min_value=0),
+            _candidate(31044, min_value=0),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "inverter_fault_2_code",
+        (
+            _candidate(39068, min_value=0),
+            _candidate(31045, min_value=0),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "inverter_fault_3_code",
+        (
+            _candidate(39069, min_value=0),
+            _candidate(31046, min_value=0),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "work_mode_code",
+        (
+            _candidate(49203, min_value=0, max_value=10),
+            _candidate(41000, min_value=0, max_value=10),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "work_mode",
+        (
+            _candidate(49203, transform=_h3_pro_work_mode_name),
+            _candidate(41000, transform=_normal_work_mode_name),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "max_charge_current",
+        (
+            _candidate(46607, scale=0.1, min_value=0, max_value=200),
+            _candidate(41007, scale=0.1, min_value=0, max_value=200),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "max_discharge_current",
+        (
+            _candidate(46608, scale=0.1, min_value=0, max_value=200),
+            _candidate(41008, scale=0.1, min_value=0, max_value=200),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "min_soc",
+        (
+            _candidate(46609, min_value=0, max_value=100),
+            _candidate(41009, min_value=0, max_value=100),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "max_soc",
+        (
+            _candidate(46610, min_value=0, max_value=100),
+            _candidate(41010, min_value=0, max_value=100),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "min_soc_on_grid",
+        (
+            _candidate(46611, min_value=0, max_value=100),
+            _candidate(41011, min_value=0, max_value=100),
+        ),
+    ),
+    _ModbusSensorSpec(
+        "import_power_limit",
+        (_candidate(46502, 46501, min_value=0, max_value=99999),),
+    ),
+    _ModbusSensorSpec(
+        "export_power_limit",
+        (_candidate(46617, 46616, min_value=0, max_value=99999),),
+    ),
+)
 
 
 class SolarwattError(UpdateFailed):
@@ -64,6 +369,7 @@ class SOLARWATTClient:
         self.session_ttl = 900
         self._last_login = 0.0
         self._log = logging.getLogger(__name__)
+        self._extended_modbus_candidate_cache: dict[str, int] = {}
 
     def _set_base(self, base: str) -> None:
         self.base = base.rstrip("/")
@@ -350,7 +656,11 @@ class SOLARWATTClient:
                 f"Cannot connect to SOLARWATT Manager: {str(e)}"
             ) from e
 
-    async def async_get_energy_overview_items(self) -> list[dict[str, Any]]:
+    async def async_get_energy_overview_items(
+        self,
+        *,
+        include_extended_modbus: bool = False,
+    ) -> list[dict[str, Any]]:
         try:
             payload = await self._async_get_json_endpoint(
                 ENERGY_OVERVIEW_PATH,
@@ -378,6 +688,14 @@ class SOLARWATTClient:
                         items.extend(
                             item
                             for item in battery_soc_to_legacy_items(things, soc)
+                            if item.get("name") not in existing_names
+                        )
+                    if include_extended_modbus:
+                        modbus_values = await self.async_get_hems_extended_modbus_values(things)
+                        existing_names.update(item.get("name") for item in items)
+                        items.extend(
+                            item
+                            for item in extended_modbus_to_legacy_items(things, modbus_values)
                             if item.get("name") not in existing_names
                         )
             except SolarwattError as err:
@@ -457,7 +775,70 @@ class SOLARWATTClient:
                 return value
         return valid_values[0] if valid_values else None
 
-    async def async_get_items(self) -> list[dict[str, Any]]:
+    async def async_get_hems_extended_modbus_values(self, things: list[Any]) -> dict[str, Any]:
+        connection = _hems_modbus_connection(things)
+        if connection is None:
+            return {}
+
+        host, port, unit = connection
+        values: dict[str, Any] = {}
+        try:
+            async with _ModbusTcpReader(host, port, unit) as reader:
+                for spec in _EXTENDED_MODBUS_SPECS:
+                    if (value := await self._async_read_extended_modbus_value(reader, spec)) is not None:
+                        values[spec.key] = value
+        except Exception as err:
+            self._log.debug(
+                "Unable to read extended Modbus data from %s:%s unit %s: %s",
+                host,
+                port,
+                unit,
+                err,
+            )
+            return values
+
+        _add_derived_modbus_values(values)
+        return values
+
+    async def _async_read_extended_modbus_value(
+        self,
+        reader: "_ModbusTcpReader",
+        spec: _ModbusSensorSpec,
+    ) -> int | float | str | None:
+        cached_index = self._extended_modbus_candidate_cache.get(spec.key)
+        candidate_indexes = list(range(len(spec.candidates)))
+        if cached_index in candidate_indexes:
+            candidate_indexes.remove(cached_index)
+            candidate_indexes.insert(0, cached_index)
+
+        for index in candidate_indexes:
+            candidate = spec.candidates[index]
+            try:
+                registers = [
+                    await reader.read_register(_MODBUS_READ_HOLDING_REGISTERS, address)
+                    for address in candidate.addresses
+                ]
+                value = _decode_modbus_candidate(candidate, registers)
+            except Exception as err:
+                self._log.debug(
+                    "Unable to read extended Modbus key %s at %s: %s",
+                    spec.key,
+                    ",".join(str(address) for address in candidate.addresses),
+                    err,
+                )
+                continue
+
+            if value is None:
+                continue
+            self._extended_modbus_candidate_cache[spec.key] = index
+            return value
+        return None
+
+    async def async_get_items(
+        self,
+        *,
+        include_extended_modbus: bool = False,
+    ) -> list[dict[str, Any]]:
         try:
             return await self._async_get_json_endpoint(
                 "/rest/items",
@@ -473,7 +854,9 @@ class SOLARWATTClient:
                     "Legacy /rest/items endpoint not found on %s; trying HEMS energy overview",
                     self.host,
                 )
-                return await self.async_get_energy_overview_items()
+                return await self.async_get_energy_overview_items(
+                    include_extended_modbus=include_extended_modbus,
+                )
             self._log.error(f"HTTP error {e.status} fetching items from {self.host}")
             raise SolarwattConnectionError(f"HTTP error {e.status}") from e
         except (ClientError, asyncio.TimeoutError) as e:
@@ -524,6 +907,163 @@ def _hems_modbus_connection(things: list[Any]) -> tuple[str, int, int] | None:
             continue
         return host, port, unit
     return None
+
+
+class _ModbusTcpReader:
+    def __init__(self, host: str, port: int, unit: int) -> None:
+        self.host = host
+        self.port = port
+        self.unit = unit
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._transaction_id = 0
+        self._cache: dict[tuple[int, int], int] = {}
+
+    async def __aenter__(self) -> "_ModbusTcpReader":
+        await self._connect()
+        return self
+
+    async def __aexit__(self, *_args) -> None:
+        await self.close()
+
+    async def _connect(self) -> None:
+        if self._writer is not None and not self._writer.is_closing():
+            return
+        self._reader, self._writer = await asyncio.wait_for(
+            asyncio.open_connection(self.host, self.port),
+            timeout=3,
+        )
+
+    async def close(self) -> None:
+        writer = self._writer
+        self._reader = None
+        self._writer = None
+        if writer is not None:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+    async def read_register(self, function: int, address: int) -> int:
+        cache_key = (function, address)
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+
+        await self._connect()
+        assert self._reader is not None
+        assert self._writer is not None
+
+        self._transaction_id = (self._transaction_id + 1) & 0xFFFF
+        transaction_id = self._transaction_id or 1
+        request = struct.pack(
+            ">HHHBBHH",
+            transaction_id,
+            0,
+            6,
+            self.unit,
+            function,
+            address,
+            1,
+        )
+        self._writer.write(request)
+        await asyncio.wait_for(self._writer.drain(), timeout=3)
+
+        try:
+            header = await asyncio.wait_for(self._reader.readexactly(7), timeout=3)
+            response_transaction_id, protocol_id, length, response_unit = struct.unpack(
+                ">HHHB",
+                header,
+            )
+            if (
+                response_transaction_id != transaction_id
+                or protocol_id != 0
+                or response_unit != self.unit
+                or length < 3
+            ):
+                raise SolarwattProtocolError("Invalid Modbus response header")
+
+            pdu = await asyncio.wait_for(self._reader.readexactly(length - 1), timeout=3)
+            response_function = pdu[0]
+            if response_function & 0x80:
+                code = pdu[1] if len(pdu) > 1 else "<missing>"
+                raise SolarwattProtocolError(f"Modbus exception {code}")
+            if response_function != function or len(pdu) < 4 or pdu[1] < 2:
+                raise SolarwattProtocolError("Invalid Modbus response payload")
+        except Exception:
+            await self.close()
+            raise
+
+        value = struct.unpack(">H", pdu[2:4])[0]
+        self._cache[cache_key] = value
+        return value
+
+
+def _decode_modbus_candidate(
+    candidate: _ModbusCandidate,
+    registers: list[int],
+) -> int | float | str | None:
+    if not registers:
+        return None
+
+    if len(registers) == 1:
+        raw = registers[0]
+        if candidate.signed and raw >= 0x8000:
+            raw -= 0x10000
+    elif len(registers) == 2:
+        low, high = registers
+        raw = (high << 16) | low
+        if candidate.signed and raw >= 0x80000000:
+            raw -= 0x100000000
+    else:
+        raw = 0
+        for offset, value in enumerate(registers):
+            raw |= value << (16 * offset)
+        if candidate.signed and raw >= 1 << (len(registers) * 16 - 1):
+            raw -= 1 << (len(registers) * 16)
+
+    if candidate.transform is not None:
+        value = candidate.transform(raw)
+    else:
+        value = raw * candidate.scale
+
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        numeric = float(value)
+        if candidate.min_value is not None and numeric < candidate.min_value:
+            return None
+        if candidate.max_value is not None and numeric > candidate.max_value:
+            return None
+        if isinstance(value, float):
+            return int(value) if value.is_integer() else round(value, 3)
+    return value
+
+
+def _add_derived_modbus_values(values: dict[str, Any]) -> None:
+    if (status := values.get("bms_1_connect_state")) is not None:
+        values["bms_1_status"] = "ONLINE" if int(status) > 0 else "OFFLINE"
+
+    fault_values = [
+        int(values.get(key) or 0)
+        for key in (
+            "inverter_fault_1_code",
+            "inverter_fault_2_code",
+            "inverter_fault_3_code",
+        )
+    ]
+    values["inverter_faults"] = _faults_text(fault_values)
+
+
+def _faults_text(fault_values: list[int]) -> str:
+    active: list[str] = []
+    for register_index, value in enumerate(fault_values, start=1):
+        if value <= 0:
+            continue
+        for bit in range(16):
+            if value & (1 << bit):
+                active.append(f"Register {register_index} bit {bit}")
+    return ", ".join(active) if active else "OK"
 
 
 async def _async_read_modbus_register(

--- a/custom_components/solarwatt_manager/client.py
+++ b/custom_components/solarwatt_manager/client.py
@@ -2,11 +2,25 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import struct
 import time
 from typing import Any
 
 from aiohttp import ClientError, ClientResponseError, ClientSession, CookieJar
 from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from .hems_api import (
+    ENERGY_OVERVIEW_PATH,
+    THINGS_PATH,
+    battery_soc_to_legacy_items,
+    energy_overview_to_items,
+    energy_overview_to_legacy_items,
+    things_to_openhab_things,
+)
+
+_FOXESS_BATTERY_SOC_ADDRESSES = (37612, 31024, 31038, 38310)
+_MODBUS_READ_HOLDING_REGISTERS = 3
+_MODBUS_READ_INPUT_REGISTERS = 4
 
 
 class SolarwattError(UpdateFailed):
@@ -336,6 +350,113 @@ class SOLARWATTClient:
                 f"Cannot connect to SOLARWATT Manager: {str(e)}"
             ) from e
 
+    async def async_get_energy_overview_items(self) -> list[dict[str, Any]]:
+        try:
+            payload = await self._async_get_json_endpoint(
+                ENERGY_OVERVIEW_PATH,
+                where=f"GET {ENERGY_OVERVIEW_PATH}",
+            )
+            if not isinstance(payload, dict):
+                raise SolarwattProtocolError("Energy overview response is not an object")
+
+            items = energy_overview_to_items(payload)
+            try:
+                things = await self._async_get_json_endpoint(
+                    THINGS_PATH,
+                    where=f"GET {THINGS_PATH}",
+                )
+                if isinstance(things, list):
+                    legacy_items = energy_overview_to_legacy_items(payload, things)
+                    existing_names = {item.get("name") for item in items}
+                    items.extend(
+                        item
+                        for item in legacy_items
+                        if item.get("name") not in existing_names
+                    )
+                    if (soc := await self.async_get_hems_battery_soc(things)) is not None:
+                        existing_names.update(item.get("name") for item in items)
+                        items.extend(
+                            item
+                            for item in battery_soc_to_legacy_items(things, soc)
+                            if item.get("name") not in existing_names
+                        )
+            except SolarwattError as err:
+                self._log.debug("Unable to build legacy HEMS item aliases: %s", err)
+
+            if not items:
+                raise SolarwattProtocolError("Energy overview response contains no supported values")
+            return items
+        except SolarwattError:
+            raise
+        except ClientResponseError as e:
+            if e.status in (401, 403):
+                raise SolarwattAuthError("HTTP error fetching HEMS energy overview") from e
+            if e.status == 404:
+                raise SolarwattNotManagerError("HEMS energy overview endpoint not found") from e
+            raise SolarwattConnectionError(f"HTTP error {e.status} fetching HEMS energy overview") from e
+        except (ClientError, asyncio.TimeoutError) as e:
+            raise SolarwattConnectionError(f"Connection error fetching HEMS energy overview: {e}") from e
+
+    async def async_get_hems_things(self) -> list[dict[str, Any]]:
+        try:
+            payload = await self._async_get_json_endpoint(
+                THINGS_PATH,
+                where=f"GET {THINGS_PATH}",
+            )
+            if not isinstance(payload, list):
+                raise SolarwattProtocolError("HEMS things response is not a list")
+            return things_to_openhab_things(payload)
+        except SolarwattError:
+            raise
+        except ClientResponseError as e:
+            if e.status in (401, 403):
+                raise SolarwattAuthError("HTTP error fetching HEMS things") from e
+            if e.status == 404:
+                raise SolarwattProtocolError("HEMS things endpoint not found") from e
+            raise SolarwattConnectionError(f"HTTP error {e.status} fetching HEMS things") from e
+        except (ClientError, asyncio.TimeoutError) as e:
+            raise SolarwattConnectionError(f"Connection error fetching HEMS things: {e}") from e
+
+    async def async_get_hems_battery_soc(self, things: list[Any]) -> int | None:
+        connection = _hems_modbus_connection(things)
+        if connection is None:
+            return None
+
+        host, port, unit = connection
+        valid_values: list[int] = []
+        for address in _FOXESS_BATTERY_SOC_ADDRESSES:
+            for function in (
+                _MODBUS_READ_HOLDING_REGISTERS,
+                _MODBUS_READ_INPUT_REGISTERS,
+            ):
+                try:
+                    value = await _async_read_modbus_register(
+                        host,
+                        port,
+                        unit,
+                        function,
+                        address,
+                    )
+                except Exception as err:
+                    self._log.debug(
+                        "Unable to read battery SoC via Modbus %s:%s unit %s address %s function %s: %s",
+                        host,
+                        port,
+                        unit,
+                        address,
+                        function,
+                        err,
+                    )
+                    continue
+
+                if 0 <= value <= 100:
+                    valid_values.append(value)
+
+        for value in valid_values:
+            if value > 0:
+                return value
+        return valid_values[0] if valid_values else None
+
     async def async_get_items(self) -> list[dict[str, Any]]:
         try:
             return await self._async_get_json_endpoint(
@@ -345,11 +466,15 @@ class SOLARWATTClient:
         except SolarwattError:
             raise
         except ClientResponseError as e:
-            self._log.error(f"HTTP error {e.status} fetching items from {self.host}")
             if e.status in (401, 403):
                 raise SolarwattAuthError(f"HTTP {e.status} fetching items") from e
             if e.status == 404:
-                raise SolarwattNotManagerError("Items endpoint not found") from e
+                self._log.debug(
+                    "Legacy /rest/items endpoint not found on %s; trying HEMS energy overview",
+                    self.host,
+                )
+                return await self.async_get_energy_overview_items()
+            self._log.error(f"HTTP error {e.status} fetching items from {self.host}")
             raise SolarwattConnectionError(f"HTTP error {e.status}") from e
         except (ClientError, asyncio.TimeoutError) as e:
             self._log.exception(f"Connection error fetching items from {self.host}: {e}")
@@ -370,9 +495,90 @@ class SOLARWATTClient:
             if e.status in (401, 403):
                 raise SolarwattAuthError("HTTP error fetching things") from e
             if e.status == 404:
-                raise SolarwattProtocolError("Things endpoint not found") from e
+                self._log.debug(
+                    "Legacy /rest/things endpoint not found on %s; trying HEMS things",
+                    self.host,
+                )
+                return await self.async_get_hems_things()
             raise SolarwattConnectionError(f"HTTP error {e.status}") from e
         except (ClientError, asyncio.TimeoutError) as e:
             raise SolarwattConnectionError(f"Connection error fetching things: {e}") from e
         except Exception as e:
             raise SolarwattConnectionError(f"Error fetching things: {e}") from e
+
+
+def _hems_modbus_connection(things: list[Any]) -> tuple[str, int, int] | None:
+    for thing in things:
+        if not isinstance(thing, dict):
+            continue
+        config = thing.get("config")
+        if not isinstance(config, dict):
+            continue
+        host = str(config.get("host") or "").strip()
+        if not host:
+            continue
+        try:
+            port = int(config.get("port") or 502)
+            unit = int(config.get("unitId") or 247)
+        except (TypeError, ValueError):
+            continue
+        return host, port, unit
+    return None
+
+
+async def _async_read_modbus_register(
+    host: str,
+    port: int,
+    unit: int,
+    function: int,
+    address: int,
+) -> int:
+    reader: asyncio.StreamReader | None = None
+    writer: asyncio.StreamWriter | None = None
+    try:
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(host, port),
+            timeout=3,
+        )
+        transaction_id = (address + function) & 0xFFFF
+        request = struct.pack(
+            ">HHHBBHH",
+            transaction_id,
+            0,
+            6,
+            unit,
+            function,
+            address,
+            1,
+        )
+        writer.write(request)
+        await asyncio.wait_for(writer.drain(), timeout=3)
+
+        header = await asyncio.wait_for(reader.readexactly(7), timeout=3)
+        response_transaction_id, protocol_id, length, response_unit = struct.unpack(
+            ">HHHB",
+            header,
+        )
+        if (
+            response_transaction_id != transaction_id
+            or protocol_id != 0
+            or response_unit != unit
+            or length < 3
+        ):
+            raise SolarwattProtocolError("Invalid Modbus response header")
+
+        pdu = await asyncio.wait_for(reader.readexactly(length - 1), timeout=3)
+        response_function = pdu[0]
+        if response_function & 0x80:
+            code = pdu[1] if len(pdu) > 1 else "<missing>"
+            raise SolarwattProtocolError(f"Modbus exception {code}")
+        if response_function != function or len(pdu) < 4 or pdu[1] < 2:
+            raise SolarwattProtocolError("Invalid Modbus response payload")
+        return struct.unpack(">H", pdu[2:4])[0]
+    finally:
+        if writer is not None:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:
+                pass

--- a/custom_components/solarwatt_manager/config_flow.py
+++ b/custom_components/solarwatt_manager/config_flow.py
@@ -13,6 +13,7 @@ from homeassistant.core import callback
 from homeassistant.data_entry_flow import section
 from .const import (
     CONF_DISABLE_DUPLICATE_ITEM_ENTITIES,
+    CONF_ENABLE_EXTENDED_MODBUS,
     CONF_ENABLED_THINGS,
     CONF_ENERGY_DELTA_KWH,
     CONF_HOST,
@@ -22,6 +23,7 @@ from .const import (
     CONF_SCAN_INTERVAL,
     CONF_USERNAME,
     DEFAULT_DISABLE_DUPLICATE_ITEM_ENTITIES,
+    DEFAULT_ENABLE_EXTENDED_MODBUS,
     DEFAULT_ENERGY_DELTA_KWH,
     DEFAULT_POWER_UNAVAILABLE_THRESHOLD,
     DEFAULT_SCAN_INTERVAL,
@@ -184,6 +186,14 @@ _OPTION_FIELD_SPECS: tuple[dict[str, Any], ...] = (
     {
         "key": CONF_DISABLE_DUPLICATE_ITEM_ENTITIES,
         "default": DEFAULT_DISABLE_DUPLICATE_ITEM_ENTITIES,
+        "normalize": _normalize_bool,
+        "coerce": bool,
+        "error": "",
+        "invalid": _is_never_invalid,
+    },
+    {
+        "key": CONF_ENABLE_EXTENDED_MODBUS,
+        "default": DEFAULT_ENABLE_EXTENDED_MODBUS,
         "normalize": _normalize_bool,
         "coerce": bool,
         "error": "",

--- a/custom_components/solarwatt_manager/const.py
+++ b/custom_components/solarwatt_manager/const.py
@@ -23,6 +23,7 @@ CONF_SCAN_INTERVAL = "scan_interval"
 CONF_ENERGY_DELTA_KWH = "energy_delta_kwh"
 CONF_POWER_UNAVAILABLE_THRESHOLD = "power_unavailable_threshold"
 CONF_DISABLE_DUPLICATE_ITEM_ENTITIES = "disable_duplicate_item_entities"
+CONF_ENABLE_EXTENDED_MODBUS = "enable_extended_modbus"
 CONF_ENABLED_THINGS = "enabled_things"
 CONF_REBUILD_ENTITY_IDS = "rebuild_entity_ids"
 
@@ -35,6 +36,7 @@ MIN_ENERGY_DELTA_KWH = 0.0
 DEFAULT_POWER_UNAVAILABLE_THRESHOLD = 3
 MIN_POWER_UNAVAILABLE_THRESHOLD = 0
 DEFAULT_DISABLE_DUPLICATE_ITEM_ENTITIES = False
+DEFAULT_ENABLE_EXTENDED_MODBUS = False
 
 DEVICE_MANUFACTURER = "SOLARWATT"
 DEVICE_MODEL = "Manager flex / rail"
@@ -215,6 +217,19 @@ def get_disable_duplicate_item_entities(options: Mapping[str, Any] | None) -> bo
     value = (options or {}).get(
         CONF_DISABLE_DUPLICATE_ITEM_ENTITIES,
         DEFAULT_DISABLE_DUPLICATE_ITEM_ENTITIES,
+    )
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def get_enable_extended_modbus(options: Mapping[str, Any] | None) -> bool:
+    """Return whether read-only extended Modbus sensors are enabled."""
+    value = (options or {}).get(
+        CONF_ENABLE_EXTENDED_MODBUS,
+        DEFAULT_ENABLE_EXTENDED_MODBUS,
     )
     if isinstance(value, bool):
         return value

--- a/custom_components/solarwatt_manager/coordinator.py
+++ b/custom_components/solarwatt_manager/coordinator.py
@@ -15,6 +15,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     MAX_SCAN_INTERVAL,
     MIN_SCAN_INTERVAL,
+    get_enable_extended_modbus,
 )
 from .entity_helpers import detach_entityless_thing_devices, ensure_parent_devices_registered
 from .state_parser import SOLARWATTItem, parse_state
@@ -74,7 +75,9 @@ class SOLARWATTCoordinator(DataUpdateCoordinator[dict[str, SOLARWATTItem]]):
     async def _async_update_data(self) -> dict[str, SOLARWATTItem]:
         # Best practice for Home Assistant: do a single poll per update interval and
         # let all entities read from the same snapshot.
-        items = await self.client.async_get_items()
+        items = await self.client.async_get_items(
+            include_extended_modbus=get_enable_extended_modbus(self.entry.options),
+        )
 
         def _to_item(name: str, it: dict[str, Any]) -> SOLARWATTItem:
             pattern = (it.get("stateDescription") or {}).get("pattern")
@@ -136,6 +139,12 @@ class SOLARWATTCoordinator(DataUpdateCoordinator[dict[str, SOLARWATTItem]]):
                         channel_metadata,
                     )
         self.things = out
+        _merge_synthetic_item_thing_mappings(
+            item_to_thing_uid,
+            item_to_channel_metadata,
+            out,
+            self.data,
+        )
         self.item_to_thing_uid = item_to_thing_uid
         self.item_to_channel_metadata = item_to_channel_metadata
         self.duplicate_item_targets = {
@@ -232,3 +241,53 @@ def _merge_channel_item_metadata(
 
     for key, value in channel_metadata.items():
         existing.setdefault(key, value)
+
+
+def _merge_synthetic_item_thing_mappings(
+    item_to_thing_uid: dict[str, str],
+    item_to_channel_metadata: dict[str, dict[str, str]],
+    things: Mapping[str, dict[str, Any]],
+    items: Mapping[str, Any] | None,
+) -> None:
+    """Map HEMS fallback and Modbus synthetic item names back to their things."""
+    thing_prefixes = {
+        uid: _synthetic_item_prefix(uid)
+        for uid in things
+        if uid and _synthetic_item_prefix(uid)
+    }
+    if not thing_prefixes:
+        return
+
+    for item_name, item in (items or {}).items():
+        if item_name in item_to_thing_uid:
+            continue
+        item_prefix = _matching_thing_prefix(str(item_name), thing_prefixes)
+        if item_prefix is None:
+            continue
+        thing_uid, _ = item_prefix
+        item_to_thing_uid[item_name] = thing_uid
+        item_to_channel_metadata.setdefault(
+            item_name,
+            {
+                "item_type": str(getattr(item, "oh_type", "") or ""),
+                "channel_label": str(getattr(item, "label", "") or ""),
+            },
+        )
+
+
+def _matching_thing_prefix(
+    item_name: str,
+    thing_prefixes: Mapping[str, str],
+) -> tuple[str, str] | None:
+    matches = [
+        (uid, prefix)
+        for uid, prefix in thing_prefixes.items()
+        if item_name == prefix or item_name.startswith(f"{prefix}_")
+    ]
+    if not matches:
+        return None
+    return max(matches, key=lambda item: len(item[1]))
+
+
+def _synthetic_item_prefix(thing_uid: str) -> str:
+    return re.sub(r"[^A-Za-z0-9]+", "_", thing_uid).strip("_")

--- a/custom_components/solarwatt_manager/hems_api.py
+++ b/custom_components/solarwatt_manager/hems_api.py
@@ -186,6 +186,96 @@ def battery_soc_to_legacy_items(
     ]
 
 
+def extended_modbus_to_legacy_items(
+    things: Sequence[Any],
+    values: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    """Build legacy-compatible item names for optional read-only Modbus data."""
+    ids_by_category = _thing_ids_by_category(things)
+    items: list[dict[str, Any]] = []
+
+    def add(
+        category: str,
+        suffix: str,
+        label: str,
+        key: str,
+        item_type: str,
+        unit: str | None = None,
+        pattern: str | None = None,
+    ) -> None:
+        thing_id = ids_by_category.get(category)
+        if not thing_id or key not in values:
+            return
+        items.append(
+            _typed_item(
+                f"{_item_prefix(thing_id)}_{suffix}",
+                label,
+                values[key],
+                item_type,
+                unit,
+                pattern,
+                "modbus",
+            )
+        )
+
+    for category, suffix, label in (
+        ("inverter", "inverter_work_pv_total", "Inverter PV Energy Total"),
+        ("pvplant", "harmonized_work_out_total", "PV Energy Total"),
+        ("location", "harmonized_work_produced_total", "PV Energy Total"),
+    ):
+        add(category, suffix, label, "solar_energy_total", "Number:Energy", "kWh", "%.2f kWh")
+    for category, suffix, label in (
+        ("inverter", "modbus_solar_energy_today", "Solar Energy Today"),
+        ("pvplant", "modbus_solar_energy_today", "Solar Energy Today"),
+    ):
+        add(category, suffix, label, "solar_energy_today", "Number:Energy", "kWh", "%.2f kWh")
+
+    add("battery", "battery_work_in_total", "Battery Charge Energy Total", "battery_charge_total", "Number:Energy", "kWh", "%.2f kWh")
+    add("battery", "modbus_battery_charge_today", "Battery Charge Energy Today", "battery_charge_today", "Number:Energy", "kWh", "%.2f kWh")
+    add("battery", "battery_work_out_total", "Battery Discharge Energy Total", "battery_discharge_total", "Number:Energy", "kWh", "%.2f kWh")
+    add("battery", "modbus_battery_discharge_today", "Battery Discharge Energy Today", "battery_discharge_today", "Number:Energy", "kWh", "%.2f kWh")
+
+    add("meter", "meter_work_out_total", "Meter Feed-in Energy Total", "feed_in_energy_total", "Number:Energy", "kWh", "%.2f kWh")
+    add("meter", "modbus_feed_in_energy_today", "Feed-in Energy Today", "feed_in_energy_today", "Number:Energy", "kWh", "%.2f kWh")
+    add("meter", "meter_work_in_total", "Meter Grid Consumption Energy Total", "grid_consumption_energy_total", "Number:Energy", "kWh", "%.2f kWh")
+    add("meter", "modbus_grid_consumption_energy_today", "Grid Consumption Energy Today", "grid_consumption_energy_today", "Number:Energy", "kWh", "%.2f kWh")
+
+    add("inverter", "inverter_work_out_total", "Inverter Yield Total", "total_yield_total", "Number:Energy", "kWh", "%.2f kWh")
+    add("inverter", "modbus_total_yield_today", "Inverter Yield Today", "total_yield_today", "Number:Energy", "kWh", "%.2f kWh")
+    add("inverter", "inverter_work_in_total", "Inverter Input Energy Total", "input_energy_total", "Number:Energy", "kWh", "%.2f kWh")
+    add("inverter", "modbus_input_energy_today", "Inverter Input Energy Today", "input_energy_today", "Number:Energy", "kWh", "%.2f kWh")
+
+    add("battery", "battery_bms_1_voltage", "Battery BMS 1 Voltage", "battery_bms_1_voltage", "Number:ElectricPotential", "V", "%.1f V")
+    add("battery", "battery_bms_1_current", "Battery BMS 1 Current", "battery_bms_1_current", "Number:ElectricCurrent", "A", "%.1f A")
+    add("battery", "battery_bms_1_temperature", "Battery BMS 1 Temperature", "battery_bms_1_temperature", "Number:Temperature", "°C", "%.1f °C")
+    add("battery", "battery_bms_1_soh", "Battery BMS 1 SoH", "battery_bms_1_soh", "Number:Dimensionless", "%", "%.0f %%")
+    add("battery", "battery_bms_1_kwh_remaining", "Battery BMS 1 kWh Remaining", "battery_bms_1_kwh_remaining", "Number:Energy", "kWh", "%.2f kWh")
+    add("battery", "battery_bms_1_cell_temperature_high", "Battery BMS 1 Cell Temperature High", "battery_bms_1_cell_temperature_high", "Number:Temperature", "°C", "%.1f °C")
+    add("battery", "battery_bms_1_cell_temperature_low", "Battery BMS 1 Cell Temperature Low", "battery_bms_1_cell_temperature_low", "Number:Temperature", "°C", "%.1f °C")
+    add("battery", "battery_bms_1_cell_voltage_high", "Battery BMS 1 Cell Voltage High", "battery_bms_1_cell_voltage_high", "Number:ElectricPotential", "V", "%.2f V")
+    add("battery", "battery_bms_1_cell_voltage_low", "Battery BMS 1 Cell Voltage Low", "battery_bms_1_cell_voltage_low", "Number:ElectricPotential", "V", "%.2f V")
+    add("battery", "bmsInfo_bms1_status", "BMS 1 Status", "bms_1_status", "String")
+
+    add("inverter", "modbus_inverter_temperature", "Inverter Temperature", "inverter_temperature", "Number:Temperature", "°C", "%.1f °C")
+    add("inverter", "modbus_inverter_state_code", "Inverter State Code", "inverter_state_code", "Number")
+    add("inverter", "modbus_inverter_fault_1_code", "Inverter Fault 1 Code", "inverter_fault_1_code", "Number")
+    add("inverter", "modbus_inverter_fault_2_code", "Inverter Fault 2 Code", "inverter_fault_2_code", "Number")
+    add("inverter", "modbus_inverter_fault_3_code", "Inverter Fault 3 Code", "inverter_fault_3_code", "Number")
+    add("inverter", "modbus_inverter_faults", "Inverter Faults", "inverter_faults", "String")
+
+    add("battery", "battery_min_soc", "Battery Min SoC", "min_soc", "Number:Dimensionless", "%", "%.0f %%")
+    add("battery", "battery_max_soc", "Battery Max SoC", "max_soc", "Number:Dimensionless", "%", "%.0f %%")
+    add("battery", "battery_min_soc_on_grid", "Battery Min SoC On Grid", "min_soc_on_grid", "Number:Dimensionless", "%", "%.0f %%")
+    add("battery", "battery_battery_maximum_charging_current", "Battery Maximum Charging Current", "max_charge_current", "Number:ElectricCurrent", "A", "%.1f A")
+    add("battery", "battery_battery_maximum_discharging_current", "Battery Maximum Discharging Current", "max_discharge_current", "Number:ElectricCurrent", "A", "%.1f A")
+    add("inverter", "modbus_work_mode_code", "Work Mode Code", "work_mode_code", "Number")
+    add("inverter", "modbus_work_mode", "Work Mode", "work_mode", "String")
+    add("inverter", "modbus_import_power_limit", "Import Power Limit", "import_power_limit", "Number:Power", "W", "%.0f W")
+    add("inverter", "modbus_export_power_limit", "Export Power Limit", "export_power_limit", "Number:Power", "W", "%.0f W")
+
+    return items
+
+
 def things_to_openhab_things(payload: Sequence[Any]) -> list[dict[str, Any]]:
     """Convert newer HEMS thing records to the shape used by existing diagnostics."""
     things: list[dict[str, Any]] = []
@@ -253,6 +343,28 @@ def _battery_item(
         "category": "energy_overview",
         "stateDescription": {"pattern": "%.0f %%"},
     }
+
+
+def _typed_item(
+    name: str,
+    label: str,
+    value: Any,
+    item_type: str,
+    unit: str | None,
+    pattern: str | None,
+    category: str,
+) -> dict[str, Any]:
+    item = {
+        "name": name,
+        "label": label,
+        "state": _typed_state(value, unit),
+        "type": item_type,
+        "editable": False,
+        "category": category,
+    }
+    if pattern:
+        item["stateDescription"] = {"pattern": pattern}
+    return item
 
 
 def _legacy_power_items(
@@ -323,6 +435,18 @@ def _percentage_state(value: int | float) -> str:
     if numeric.is_integer():
         return f"{int(numeric)} %"
     return f"{numeric} %"
+
+
+def _typed_state(value: Any, unit: str | None) -> str:
+    if isinstance(value, bool) or value is None:
+        return "NULL"
+    if isinstance(value, (int, float)):
+        if not isinstance(value, bool) and float(value).is_integer():
+            rendered = str(int(value))
+        else:
+            rendered = str(value)
+        return f"{rendered} {unit}" if unit else rendered
+    return str(value)
 
 
 def _numeric_value(payload: Mapping[str, Any], key: str) -> float | None:

--- a/custom_components/solarwatt_manager/hems_api.py
+++ b/custom_components/solarwatt_manager/hems_api.py
@@ -1,0 +1,376 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import re
+from typing import Any
+
+
+ENERGY_OVERVIEW_PATH = "/rest/hems-configurator/energy-overview"
+THINGS_PATH = "/rest/hems-configurator/things"
+
+_POWER_ITEM_DEFINITIONS: tuple[tuple[str, str, str], ...] = (
+    ("production", "energy_overview_pv_production", "PV production"),
+    ("feedIn", "energy_overview_grid_feed_in", "Grid feed in"),
+    ("feedOut", "energy_overview_grid_import", "Grid import"),
+    (
+        "householdConsumption",
+        "energy_overview_household_consumption",
+        "Household consumption",
+    ),
+    ("storagePowerIn", "energy_overview_battery_charge", "Battery charge"),
+    ("storagePowerOut", "energy_overview_battery_discharge", "Battery discharge"),
+)
+
+
+def energy_overview_to_items(payload: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Convert the newer HEMS energy overview response to OpenHAB-like items."""
+    items = [
+        _power_item(item_name, label, payload.get(source_key), "energy_overview")
+        for source_key, item_name, label in _POWER_ITEM_DEFINITIONS
+        if source_key in payload
+    ]
+    return items
+
+
+def energy_overview_to_legacy_items(
+    payload: Mapping[str, Any],
+    things: Sequence[Any],
+) -> list[dict[str, Any]]:
+    """Build legacy item names from the HEMS overview for existing entity IDs."""
+    items: list[dict[str, Any]] = []
+    ids_by_category = _thing_ids_by_category(things)
+
+    if location_id := ids_by_category.get("location"):
+        items.extend(
+            _legacy_power_items(
+                location_id,
+                "harmonized",
+                (
+                    ("power_produced", "Power Produced", payload.get("production")),
+                    ("power_consumed", "Power Consumed", payload.get("householdConsumption")),
+                    ("power_consumed_from_grid", "Power Consumed From Grid", payload.get("feedOut")),
+                    ("power_out", "Power Out", payload.get("feedIn")),
+                    ("power_buffered", "Power Buffered", payload.get("storagePowerIn")),
+                    ("power_released", "Power Released", payload.get("storagePowerOut")),
+                    (
+                        "power_consumed_from_storage",
+                        "Power Consumed From Storage",
+                        payload.get("storagePowerOut"),
+                    ),
+                    (
+                        "power_out_from_storage",
+                        "Power Out From Storage",
+                        payload.get("storagePowerOut"),
+                    ),
+                    (
+                        "power_buffered_from_producers",
+                        "Power Buffered From Producers",
+                        payload.get("storagePowerIn"),
+                    ),
+                    (
+                        "power_self_consumed",
+                        "Power Self Consumed",
+                        _self_consumed_power(payload),
+                    ),
+                ),
+            )
+        )
+
+    if pvplant_id := ids_by_category.get("pvplant"):
+        items.extend(
+            _legacy_power_items(
+                pvplant_id,
+                "harmonized",
+                (("power_out", "Power Out", payload.get("production")),),
+            )
+        )
+
+    if inverter_id := ids_by_category.get("inverter"):
+        items.extend(
+            _legacy_power_items(
+                inverter_id,
+                "",
+                (
+                    (
+                        "inverter_total_pv_input_power",
+                        "Inverter Total PV Input Power",
+                        payload.get("production"),
+                    ),
+                    (
+                        "electricData_mppt_total_power",
+                        "electricData MPPT Total Power",
+                        payload.get("production"),
+                    ),
+                ),
+            )
+        )
+        items.extend(
+            _legacy_power_items(
+                inverter_id,
+                "harmonized",
+                (
+                    ("mppt_dc_power", "MPPT DC Power", payload.get("production")),
+                    ("power_out", "Power Out", payload.get("production")),
+                ),
+            )
+        )
+
+    if meter_id := ids_by_category.get("meter"):
+        items.extend(
+            _legacy_power_items(
+                meter_id,
+                "harmonized",
+                (
+                    ("power_in", "Power In", payload.get("feedOut")),
+                    ("power_out", "Power Out", payload.get("feedIn")),
+                ),
+            )
+        )
+        items.append(
+            _power_item(
+                f"{_item_prefix(meter_id)}_meter_active_power_total",
+                "Meter Active Power Total",
+                _net_grid_power(payload),
+                "energy_overview",
+            )
+        )
+
+    if battery_id := ids_by_category.get("battery"):
+        items.extend(
+            _legacy_power_items(
+                battery_id,
+                "harmonized",
+                (
+                    ("power_in", "Power In", payload.get("storagePowerIn")),
+                    ("power_out", "Power Out", payload.get("storagePowerOut")),
+                ),
+            )
+        )
+        items.extend(
+            _legacy_power_items(
+                battery_id,
+                "battery",
+                (
+                    ("battery_calculated_power", "Battery Calculated Power", _net_battery_power(payload)),
+                    ("bms_power", "Battery BMS Power", _net_battery_power(payload)),
+                    ("bms_1_power", "Battery BMS 1 Power", _net_battery_power(payload)),
+                ),
+            )
+        )
+
+    return items
+
+
+def battery_soc_to_legacy_items(
+    things: Sequence[Any],
+    soc: int | float,
+) -> list[dict[str, Any]]:
+    """Build legacy battery SoC item names from an inverter Modbus read."""
+    ids_by_category = _thing_ids_by_category(things)
+    battery_id = ids_by_category.get("battery")
+    if not battery_id:
+        return []
+
+    prefix = _item_prefix(battery_id)
+    return [
+        _battery_item(
+            f"{prefix}_battery_bms_soc",
+            "Battery BMS SoC",
+            soc,
+        ),
+        _battery_item(
+            f"{prefix}_battery_bms_1_soc",
+            "Battery BMS 1 SoC",
+            soc,
+        ),
+    ]
+
+
+def things_to_openhab_things(payload: Sequence[Any]) -> list[dict[str, Any]]:
+    """Convert newer HEMS thing records to the shape used by existing diagnostics."""
+    things: list[dict[str, Any]] = []
+    for raw_thing in payload:
+        if not isinstance(raw_thing, Mapping):
+            continue
+        uid = str(raw_thing.get("id") or "").strip()
+        if not uid:
+            continue
+
+        thing_type = raw_thing.get("thingType")
+        thing_type = thing_type if isinstance(thing_type, Mapping) else {}
+        type_uid = str(thing_type.get("id") or "").strip()
+        responsible_bridge = raw_thing.get("responsibleBridge")
+        responsible_bridge = (
+            responsible_bridge if isinstance(responsible_bridge, Mapping) else {}
+        )
+
+        properties = _thing_properties(raw_thing, thing_type)
+        thing: dict[str, Any] = {
+            "UID": uid,
+            "uid": uid,
+            "label": raw_thing.get("label") or uid,
+            "thingTypeUID": type_uid,
+            "thingTypeUid": type_uid,
+            "statusInfo": raw_thing.get("statusInfo") or {},
+            "properties": properties,
+            "channels": [],
+        }
+        if bridge_uid := str(responsible_bridge.get("id") or "").strip():
+            thing["bridgeUID"] = bridge_uid
+            thing["bridgeUid"] = bridge_uid
+        things.append(thing)
+    return things
+
+
+def _power_item(
+    name: str,
+    label: str,
+    value: Any,
+    category: str,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "label": label,
+        "state": _power_state(value),
+        "type": "Number:Power",
+        "editable": False,
+        "category": category,
+        "stateDescription": {"pattern": "%.0f W"},
+    }
+
+
+def _battery_item(
+    name: str,
+    label: str,
+    value: int | float,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "label": label,
+        "state": _percentage_state(value),
+        "type": "Number:Dimensionless",
+        "editable": False,
+        "category": "energy_overview",
+        "stateDescription": {"pattern": "%.0f %%"},
+    }
+
+
+def _legacy_power_items(
+    thing_id: str,
+    group: str,
+    definitions: Sequence[tuple[str, str, Any]],
+) -> list[dict[str, Any]]:
+    prefix = _item_prefix(thing_id)
+    group_prefix = f"{group}_" if group else ""
+    return [
+        _power_item(
+            f"{prefix}_{group_prefix}{suffix}",
+            label,
+            value,
+            "energy_overview",
+        )
+        for suffix, label, value in definitions
+        if value is not None
+    ]
+
+
+def _thing_ids_by_category(things: Sequence[Any]) -> dict[str, str]:
+    ids: dict[str, str] = {}
+    for raw_thing in things:
+        if not isinstance(raw_thing, Mapping):
+            continue
+        thing_id = str(raw_thing.get("id") or "").strip()
+        if not thing_id:
+            continue
+        thing_type = raw_thing.get("thingType")
+        thing_type = thing_type if isinstance(thing_type, Mapping) else {}
+        type_id = str(thing_type.get("id") or "").strip().lower()
+        category = thing_type.get("category")
+        category = category if isinstance(category, Mapping) else {}
+        category_type = str(category.get("type") or "").strip().upper()
+
+        if "kiwigrid-location" in type_id:
+            ids.setdefault("location", thing_id)
+        elif type_id.startswith("pvplant:"):
+            ids.setdefault("pvplant", thing_id)
+        elif "inverter" in type_id and "bridge" not in type_id:
+            ids.setdefault("inverter", thing_id)
+        elif "battery" in type_id or category_type == "STORAGES":
+            ids.setdefault("battery", thing_id)
+        elif "meter" in type_id or category_type == "POWER_METERS":
+            ids.setdefault("meter", thing_id)
+    return ids
+
+
+def _item_prefix(thing_id: str) -> str:
+    return re.sub(r"[^A-Za-z0-9]+", "_", thing_id).strip("_")
+
+
+def _power_state(value: Any) -> str:
+    if isinstance(value, bool) or value is None:
+        return "NULL"
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return "NULL"
+    if numeric.is_integer():
+        return f"{int(numeric)} W"
+    return f"{numeric} W"
+
+
+def _percentage_state(value: int | float) -> str:
+    numeric = float(value)
+    if numeric.is_integer():
+        return f"{int(numeric)} %"
+    return f"{numeric} %"
+
+
+def _numeric_value(payload: Mapping[str, Any], key: str) -> float | None:
+    value = payload.get(key)
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _net_grid_power(payload: Mapping[str, Any]) -> float | None:
+    feed_out = _numeric_value(payload, "feedOut")
+    feed_in = _numeric_value(payload, "feedIn")
+    if feed_out is None and feed_in is None:
+        return None
+    return (feed_out or 0) - (feed_in or 0)
+
+
+def _net_battery_power(payload: Mapping[str, Any]) -> float | None:
+    storage_out = _numeric_value(payload, "storagePowerOut")
+    storage_in = _numeric_value(payload, "storagePowerIn")
+    if storage_out is None and storage_in is None:
+        return None
+    return (storage_out or 0) - (storage_in or 0)
+
+
+def _self_consumed_power(payload: Mapping[str, Any]) -> float | None:
+    production = _numeric_value(payload, "production")
+    feed_in = _numeric_value(payload, "feedIn")
+    if production is None and feed_in is None:
+        return None
+    return max((production or 0) - (feed_in or 0), 0)
+
+
+def _thing_properties(
+    raw_thing: Mapping[str, Any],
+    thing_type: Mapping[str, Any],
+) -> dict[str, str]:
+    category = thing_type.get("category")
+    category = category if isinstance(category, Mapping) else {}
+    properties: dict[str, str] = {}
+    for key, value in (
+        ("serialNumber", raw_thing.get("serialNumber")),
+        ("thingTypeTitle", thing_type.get("title")),
+        ("thingTypeCategory", category.get("type")),
+    ):
+        if text := str(value or "").strip():
+            properties[key] = text
+    return properties

--- a/custom_components/solarwatt_manager/sensor_meta.py
+++ b/custom_components/solarwatt_manager/sensor_meta.py
@@ -282,6 +282,10 @@ def _is_total_increasing_energy(
         "kumulativ",
         "extrapolated",
         "lifetime",
+        "_today",
+        "today_",
+        "_daily",
+        "daily_",
     )
     if any(token in item_name for token in total_tokens):
         return True

--- a/custom_components/solarwatt_manager/translations/de.json
+++ b/custom_components/solarwatt_manager/translations/de.json
@@ -26,7 +26,8 @@
           "scan_interval": "Update-Intervall (Sekunden)",
           "energy_delta_kwh": "Schwellwert Energy-Änderung (kWh). Schreiben nur bei >= Wert; 0 = bei jedem Update schreiben",
           "power_unavailable_threshold": "Power-unavailable-Schwellwert (Polls). Letzten Wert bis zum N-ten unavailable halten; 0 = deaktiviert",
-          "disable_duplicate_item_entities": "Doppelte Item-Entitäten deaktivieren und UID-basierten Kanal-Eintrag bevorzugen"
+          "disable_duplicate_item_entities": "Doppelte Item-Entitäten deaktivieren und UID-basierten Kanal-Eintrag bevorzugen",
+          "enable_extended_modbus": "Zusätzliche Wechselrichter- und Speicherdaten per Modbus lesen (nur lesend)"
         }
       },
       "devices": {
@@ -57,7 +58,8 @@
           "scan_interval": "Update-Intervall (Sekunden)",
           "energy_delta_kwh": "Schwellwert Energy-Änderung (kWh). Schreiben nur bei >= Wert; 0 = bei jedem Update schreiben",
           "power_unavailable_threshold": "Power-unavailable-Schwellwert (Polls). Letzten Wert bis zum N-ten unavailable halten; 0 = deaktiviert",
-          "disable_duplicate_item_entities": "Doppelte Item-Entitäten deaktivieren und UID-basierten Kanal-Eintrag bevorzugen"
+          "disable_duplicate_item_entities": "Doppelte Item-Entitäten deaktivieren und UID-basierten Kanal-Eintrag bevorzugen",
+          "enable_extended_modbus": "Zusätzliche Wechselrichter- und Speicherdaten per Modbus lesen (nur lesend)"
         }
       }
     }

--- a/custom_components/solarwatt_manager/translations/en.json
+++ b/custom_components/solarwatt_manager/translations/en.json
@@ -26,7 +26,8 @@
           "scan_interval": "Update interval (seconds)",
           "energy_delta_kwh": "Energy change threshold (kWh). Write only if >= value; 0 = write every update",
           "power_unavailable_threshold": "Power unavailable threshold (polls). Keep the last value until the Nth unavailable; 0 = disable",
-          "disable_duplicate_item_entities": "Disable duplicate item entities and prefer the UID-based channel item"
+          "disable_duplicate_item_entities": "Disable duplicate item entities and prefer the UID-based channel item",
+          "enable_extended_modbus": "Read additional inverter and battery data via Modbus (read-only)"
         }
       },
       "devices": {
@@ -57,7 +58,8 @@
           "scan_interval": "Update interval (seconds)",
           "energy_delta_kwh": "Energy change threshold (kWh). Write only if >= value; 0 = write every update",
           "power_unavailable_threshold": "Power unavailable threshold (polls). Keep the last value until the Nth unavailable; 0 = disable",
-          "disable_duplicate_item_entities": "Disable duplicate item entities and prefer the UID-based channel item"
+          "disable_duplicate_item_entities": "Disable duplicate item entities and prefer the UID-based channel item",
+          "enable_extended_modbus": "Read additional inverter and battery data via Modbus (read-only)"
         }
       }
     }

--- a/custom_components/solarwatt_manager/translations/fr.json
+++ b/custom_components/solarwatt_manager/translations/fr.json
@@ -26,7 +26,8 @@
           "scan_interval": "Intervalle de mise à jour (secondes)",
           "energy_delta_kwh": "Seuil de variation d'énergie (kWh). Écrire uniquement si >= valeur ; 0 = écrire à chaque mise à jour",
           "power_unavailable_threshold": "Seuil d'indisponibilité de puissance (polls). Conserver la dernière valeur jusqu'à la N-ième indisponibilité ; 0 = désactiver",
-          "disable_duplicate_item_entities": "Désactiver les entités item dupliquées et préférer l'item de canal basé sur l'UID"
+          "disable_duplicate_item_entities": "Désactiver les entités item dupliquées et préférer l'item de canal basé sur l'UID",
+          "enable_extended_modbus": "Lire les données supplémentaires de l'onduleur et de la batterie via Modbus (lecture seule)"
         }
       },
       "devices": {
@@ -57,7 +58,8 @@
           "scan_interval": "Intervalle de mise à jour (secondes)",
           "energy_delta_kwh": "Seuil de variation d'énergie (kWh). Écrire uniquement si >= valeur ; 0 = écrire à chaque mise à jour",
           "power_unavailable_threshold": "Seuil d'indisponibilité de puissance (polls). Conserver la dernière valeur jusqu'à la N-ième indisponibilité ; 0 = désactiver",
-          "disable_duplicate_item_entities": "Désactiver les entités item dupliquées et préférer l'item de canal basé sur l'UID"
+          "disable_duplicate_item_entities": "Désactiver les entités item dupliquées et préférer l'item de canal basé sur l'UID",
+          "enable_extended_modbus": "Lire les données supplémentaires de l'onduleur et de la batterie via Modbus (lecture seule)"
         }
       }
     }

--- a/custom_components/solarwatt_manager/translations/it.json
+++ b/custom_components/solarwatt_manager/translations/it.json
@@ -26,7 +26,8 @@
           "scan_interval": "Intervallo di aggiornamento (secondi)",
           "energy_delta_kwh": "Soglia variazione energia (kWh). Scrivi solo se >= valore; 0 = scrivi a ogni aggiornamento",
           "power_unavailable_threshold": "Soglia unavailable potenza (poll). Mantieni l'ultimo valore fino all'N-esimo unavailable; 0 = disattiva",
-          "disable_duplicate_item_entities": "Disattiva le entità item duplicate e preferisci l'item canale basato sull'UID"
+          "disable_duplicate_item_entities": "Disattiva le entità item duplicate e preferisci l'item canale basato sull'UID",
+          "enable_extended_modbus": "Leggi dati aggiuntivi di inverter e batteria tramite Modbus (solo lettura)"
         }
       },
       "devices": {
@@ -57,7 +58,8 @@
           "scan_interval": "Intervallo di aggiornamento (secondi)",
           "energy_delta_kwh": "Soglia variazione energia (kWh). Scrivi solo se >= valore; 0 = scrivi a ogni aggiornamento",
           "power_unavailable_threshold": "Soglia unavailable potenza (poll). Mantieni l'ultimo valore fino all'N-esimo unavailable; 0 = disattiva",
-          "disable_duplicate_item_entities": "Disattiva le entità item duplicate e preferisci l'item canale basato sull'UID"
+          "disable_duplicate_item_entities": "Disattiva le entità item duplicate e preferisci l'item canale basato sull'UID",
+          "enable_extended_modbus": "Leggi dati aggiuntivi di inverter e batteria tramite Modbus (solo lettura)"
         }
       }
     }

--- a/custom_components/solarwatt_manager/translations/nl.json
+++ b/custom_components/solarwatt_manager/translations/nl.json
@@ -26,7 +26,8 @@
           "scan_interval": "Update-interval (seconden)",
           "energy_delta_kwh": "Drempel voor energieverandering (kWh). Alleen schrijven bij >= waarde; 0 = schrijven bij elke update",
           "power_unavailable_threshold": "Power-unavailable-drempel (polls). Laat de laatste waarde staan tot de N-de unavailable; 0 = uitschakelen",
-          "disable_duplicate_item_entities": "Dubbele item-entiteiten uitschakelen en het UID-gebaseerde kanaalitem prefereren"
+          "disable_duplicate_item_entities": "Dubbele item-entiteiten uitschakelen en het UID-gebaseerde kanaalitem prefereren",
+          "enable_extended_modbus": "Extra omvormer- en batterijgegevens via Modbus lezen (alleen-lezen)"
         }
       },
       "devices": {
@@ -57,7 +58,8 @@
           "scan_interval": "Update-interval (seconden)",
           "energy_delta_kwh": "Drempel voor energieverandering (kWh). Alleen schrijven bij >= waarde; 0 = schrijven bij elke update",
           "power_unavailable_threshold": "Power-unavailable-drempel (polls). Laat de laatste waarde staan tot de N-de unavailable; 0 = uitschakelen",
-          "disable_duplicate_item_entities": "Dubbele item-entiteiten uitschakelen en het UID-gebaseerde kanaalitem prefereren"
+          "disable_duplicate_item_entities": "Dubbele item-entiteiten uitschakelen en het UID-gebaseerde kanaalitem prefereren",
+          "enable_extended_modbus": "Extra omvormer- en batterijgegevens via Modbus lezen (alleen-lezen)"
         }
       }
     }

--- a/tests/test_hems_api.py
+++ b/tests/test_hems_api.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from .module_loader import load_component_module
+
+hems_api = load_component_module("hems_api")
+energy_overview_to_items = hems_api.energy_overview_to_items
+energy_overview_to_legacy_items = hems_api.energy_overview_to_legacy_items
+battery_soc_to_legacy_items = hems_api.battery_soc_to_legacy_items
+things_to_openhab_things = hems_api.things_to_openhab_things
+
+
+def test_energy_overview_to_items_builds_power_items():
+    items = energy_overview_to_items(
+        {
+            "production": 240,
+            "feedIn": 0,
+            "feedOut": 7.5,
+            "householdConsumption": 426,
+            "storagePowerIn": None,
+            "storagePowerOut": 178,
+        }
+    )
+
+    assert [item["name"] for item in items] == [
+        "energy_overview_pv_production",
+        "energy_overview_grid_feed_in",
+        "energy_overview_grid_import",
+        "energy_overview_household_consumption",
+        "energy_overview_battery_charge",
+        "energy_overview_battery_discharge",
+    ]
+    assert [item["state"] for item in items] == [
+        "240 W",
+        "0 W",
+        "7.5 W",
+        "426 W",
+        "NULL",
+        "178 W",
+    ]
+    assert all(item["type"] == "Number:Power" for item in items)
+
+
+def test_energy_overview_to_legacy_items_builds_existing_power_names():
+    items = energy_overview_to_legacy_items(
+        {
+            "production": 329,
+            "feedIn": 0,
+            "feedOut": 9,
+            "householdConsumption": 445,
+            "storagePowerIn": 0,
+            "storagePowerOut": 107,
+        },
+        [
+            {
+                "id": "kiwigrid-location:standard:location-id",
+                "thingType": {"id": "kiwigrid-location:standard"},
+            },
+            {
+                "id": "pvplant:standard:pv-id",
+                "thingType": {"id": "pvplant:standard"},
+            },
+            {
+                "id": "foxesshybrid:inverter:serial",
+                "thingType": {"id": "foxesshybrid:inverter"},
+            },
+            {
+                "id": "foxesshybrid:meter:serial",
+                "thingType": {
+                    "id": "foxesshybrid:meter",
+                    "category": {"type": "POWER_METERS"},
+                },
+            },
+            {
+                "id": "foxesshybrid:battery:serial",
+                "thingType": {
+                    "id": "foxesshybrid:battery",
+                    "category": {"type": "STORAGES"},
+                },
+            },
+        ],
+    )
+
+    states = {item["name"]: item["state"] for item in items}
+    assert states["kiwigrid_location_standard_location_id_harmonized_power_consumed"] == "445 W"
+    assert states["kiwigrid_location_standard_location_id_harmonized_power_consumed_from_grid"] == "9 W"
+    assert states["pvplant_standard_pv_id_harmonized_power_out"] == "329 W"
+    assert states["foxesshybrid_inverter_serial_inverter_total_pv_input_power"] == "329 W"
+    assert states["foxesshybrid_meter_serial_harmonized_power_in"] == "9 W"
+    assert states["foxesshybrid_meter_serial_harmonized_power_out"] == "0 W"
+    assert states["foxesshybrid_meter_serial_meter_active_power_total"] == "9 W"
+    assert states["foxesshybrid_battery_serial_harmonized_power_in"] == "0 W"
+    assert states["foxesshybrid_battery_serial_harmonized_power_out"] == "107 W"
+
+
+def test_battery_soc_to_legacy_items_builds_existing_soc_names():
+    items = battery_soc_to_legacy_items(
+        [
+            {
+                "id": "foxesshybrid:battery:serial",
+                "thingType": {
+                    "id": "foxesshybrid:battery",
+                    "category": {"type": "STORAGES"},
+                },
+            },
+        ],
+        56,
+    )
+
+    assert items == [
+        {
+            "name": "foxesshybrid_battery_serial_battery_bms_soc",
+            "label": "Battery BMS SoC",
+            "state": "56 %",
+            "type": "Number:Dimensionless",
+            "editable": False,
+            "category": "energy_overview",
+            "stateDescription": {"pattern": "%.0f %%"},
+        },
+        {
+            "name": "foxesshybrid_battery_serial_battery_bms_1_soc",
+            "label": "Battery BMS 1 SoC",
+            "state": "56 %",
+            "type": "Number:Dimensionless",
+            "editable": False,
+            "category": "energy_overview",
+            "stateDescription": {"pattern": "%.0f %%"},
+        },
+    ]
+
+
+def test_things_to_openhab_things_preserves_diagnostics_metadata():
+    things = things_to_openhab_things(
+        [
+            {
+                "id": "foxesshybrid:inverter:123",
+                "label": "SOLARWATT Inverter",
+                "thingType": {
+                    "id": "foxesshybrid:inverter",
+                    "title": "SOLARWATT Inverter vision",
+                    "category": {"type": "INVERTERS"},
+                },
+                "statusInfo": {"status": "ONLINE", "statusDetail": "NONE"},
+                "serialNumber": "123",
+                "responsibleBridge": {"id": "foxesshybrid:bridge:123"},
+            },
+            {"label": "Missing id"},
+        ]
+    )
+
+    assert things == [
+        {
+            "UID": "foxesshybrid:inverter:123",
+            "uid": "foxesshybrid:inverter:123",
+            "label": "SOLARWATT Inverter",
+            "thingTypeUID": "foxesshybrid:inverter",
+            "thingTypeUid": "foxesshybrid:inverter",
+            "statusInfo": {"status": "ONLINE", "statusDetail": "NONE"},
+            "properties": {
+                "serialNumber": "123",
+                "thingTypeTitle": "SOLARWATT Inverter vision",
+                "thingTypeCategory": "INVERTERS",
+            },
+            "channels": [],
+            "bridgeUID": "foxesshybrid:bridge:123",
+            "bridgeUid": "foxesshybrid:bridge:123",
+        }
+    ]

--- a/tests/test_hems_api.py
+++ b/tests/test_hems_api.py
@@ -6,6 +6,7 @@ hems_api = load_component_module("hems_api")
 energy_overview_to_items = hems_api.energy_overview_to_items
 energy_overview_to_legacy_items = hems_api.energy_overview_to_legacy_items
 battery_soc_to_legacy_items = hems_api.battery_soc_to_legacy_items
+extended_modbus_to_legacy_items = hems_api.extended_modbus_to_legacy_items
 things_to_openhab_things = hems_api.things_to_openhab_things
 
 
@@ -126,6 +127,62 @@ def test_battery_soc_to_legacy_items_builds_existing_soc_names():
             "stateDescription": {"pattern": "%.0f %%"},
         },
     ]
+
+
+def test_extended_modbus_to_legacy_items_restores_energy_and_bms_names():
+    items = extended_modbus_to_legacy_items(
+        [
+            {
+                "id": "kiwigrid-location:standard:location-id",
+                "thingType": {"id": "kiwigrid-location:standard"},
+            },
+            {
+                "id": "pvplant:standard:pv-id",
+                "thingType": {"id": "pvplant:standard"},
+            },
+            {
+                "id": "foxesshybrid:inverter:serial",
+                "thingType": {"id": "foxesshybrid:inverter"},
+            },
+            {
+                "id": "foxesshybrid:meter:serial",
+                "thingType": {
+                    "id": "foxesshybrid:meter",
+                    "category": {"type": "POWER_METERS"},
+                },
+            },
+            {
+                "id": "foxesshybrid:battery:serial",
+                "thingType": {
+                    "id": "foxesshybrid:battery",
+                    "category": {"type": "STORAGES"},
+                },
+            },
+        ],
+        {
+            "solar_energy_total": 346.4,
+            "battery_charge_total": 144.4,
+            "battery_discharge_total": 139.3,
+            "feed_in_energy_total": 2.4,
+            "grid_consumption_energy_total": 103.3,
+            "battery_bms_1_voltage": 356.3,
+            "battery_bms_1_temperature": 33.8,
+            "battery_bms_1_soh": 100,
+            "bms_1_status": "ONLINE",
+            "work_mode": "Self Use",
+        },
+    )
+
+    states = {item["name"]: item for item in items}
+    assert states["foxesshybrid_inverter_serial_inverter_work_pv_total"]["state"] == "346.4 kWh"
+    assert states["pvplant_standard_pv_id_harmonized_work_out_total"]["state"] == "346.4 kWh"
+    assert states["foxesshybrid_battery_serial_battery_work_in_total"]["state"] == "144.4 kWh"
+    assert states["foxesshybrid_battery_serial_battery_work_out_total"]["state"] == "139.3 kWh"
+    assert states["foxesshybrid_meter_serial_meter_work_out_total"]["state"] == "2.4 kWh"
+    assert states["foxesshybrid_meter_serial_meter_work_in_total"]["state"] == "103.3 kWh"
+    assert states["foxesshybrid_battery_serial_battery_bms_1_voltage"]["type"] == "Number:ElectricPotential"
+    assert states["foxesshybrid_battery_serial_bmsInfo_bms1_status"]["state"] == "ONLINE"
+    assert states["foxesshybrid_inverter_serial_modbus_work_mode"]["state"] == "Self Use"
 
 
 def test_things_to_openhab_things_preserves_diagnostics_metadata():


### PR DESCRIPTION
## Summary

Adds a compatibility fallback for newer KiwOS Edge systems where the legacy `/rest/items` and `/rest/things` endpoints return `404`, while live data and thing metadata are available through the HEMS configurator API.

## What changed

- Keep the existing `/rest/items` and `/rest/things` endpoints as the primary path for current installations.
- When `/rest/items` returns `404`, fetch `/rest/hems-configurator/energy-overview` and convert its live values into OpenHAB-like `Number:Power` items.
- Emit legacy item aliases derived from `/rest/hems-configurator/things`, so existing entity IDs such as Kiwigrid location, inverter PV power, meter import/export, and battery charge/discharge power continue to receive data.
- When the HEMS thing metadata exposes a Modbus TCP bridge, read FoxESS-compatible battery SoC registers read-only and emit the existing `battery_bms_soc` aliases.
- Add an opt-in integration option, `Read additional inverter and battery data via Modbus (read-only)`.
- When that option is enabled, read additional validated Modbus registers for PV/grid/battery energy totals, BMS voltage/current/temperature/SoH/kWh remaining/cell spread, inverter temperature/state/faults, work mode, SoC limits, current limits, and import/export power limits.
- Map synthetic HEMS/Modbus item names back to their detected SOLARWATT things, so new sensors are grouped under the inverter, battery, meter, or PV plant devices.
- When `/rest/things` returns `404`, fetch `/rest/hems-configurator/things` and normalize basic diagnostics metadata into the existing thing shape.
- Add converter tests, update translations, and document the compatibility path.

## Root cause

On a tested SOLARWATT Manager with KiwOS Edge `10.26.24.4` / EM setup feature `4.64.1.45`, authenticated requests to `/rest/items` and `/rest/things` return `404`, but `/rest/hems-configurator/energy-overview` returns live production, grid, household, and battery power values. The inverter bridge exposes FoxESS-compatible Modbus TCP on port `502` with unit ID `247`.

## Validation

- Local tests: `python -m pytest -q` -> 27 passed.
- Local compile check: `python -m compileall -q custom_components/solarwatt_manager`.
- Home Assistant deployment check: `ha core check` passed on HA `2026.6.4`.
- Deployed to a live Home Assistant instance and restarted Core without Solarwatt/Modbus errors in the fresh logs.
- Direct deployed-component opt-in read test returned 73 items, including:
  - `foxesshybrid_inverter_2R6H5020566C017_inverter_work_pv_total=346.5 kWh`
  - `foxesshybrid_battery_2R6H5020566C017_battery_work_in_total=144.4 kWh`
  - `foxesshybrid_battery_2R6H5020566C017_battery_work_out_total=139.3 kWh`
  - `foxesshybrid_battery_2R6H5020566C017_battery_bms_1_voltage=355.7 V`
  - `foxesshybrid_battery_2R6H5020566C017_battery_bms_1_temperature=33.8 °C`
  - `foxesshybrid_battery_2R6H5020566C017_battery_bms_1_soh=100 %`
  - `foxesshybrid_battery_2R6H5020566C017_bmsInfo_bms1_status=ONLINE`
  - `foxesshybrid_inverter_2R6H5020566C017_modbus_work_mode=Self Use`
  - `foxesshybrid_inverter_2R6H5020566C017_modbus_inverter_faults=OK`
  - `foxesshybrid_meter_2R6H5020566C017_meter_work_in_total=103.3 kWh`
  - `foxesshybrid_meter_2R6H5020566C017_meter_work_out_total=2.4 kWh`
